### PR TITLE
Added ability to play and queue Spotify tracks

### DIFF
--- a/SonosKit/SonosController.h
+++ b/SonosKit/SonosController.h
@@ -39,6 +39,7 @@ typedef NS_ENUM(NSInteger, SonosRequestType) {
 // AVTransport
 
 - (void)queue:(NSString *)track completion:(void(^)(NSDictionary *response, NSError *error))block;
+- (void)queueSpotify:(NSString *)track parent:(NSString *)parent completion:(void (^)(NSDictionary *, NSError *))block;
 - (void)getMediaInfo:(void(^)(NSDictionary *response, NSError *error))block;
 - (void)getTransportInfo:(void(^)(BOOL playing, NSDictionary *response, NSError *error))block;
 - (void)getPositionInfo:(void(^)(NSDictionary *track, NSDictionary *response, NSError *error))block;
@@ -46,6 +47,7 @@ typedef NS_ENUM(NSInteger, SonosRequestType) {
 - (void)getTransportSettings:(void(^)(NSDictionary *response, NSError *error))block;
 - (void)stop:(void(^)(NSDictionary *response, NSError *error))block;
 - (void)play:(NSString *)uri completion:(void(^)(NSDictionary *response, NSError *error))block;
+- (void)playSpotify:(NSString *)uri parent:(NSString *)parent completion:(void(^)(NSDictionary *response, NSError *error))block;
 - (void)pause:(void(^)(NSDictionary *response, NSError *error))block;
 - (void)next:(void(^)(NSDictionary *response, NSError *error))block;
 - (void)previous:(void(^)(NSDictionary *response, NSError *error))block;


### PR DESCRIPTION
In order to play spotify tracks, you need to supply some DIDL metadata for Sonos to lookup the Spotify metadata.

You may leave `parent` nil, but then Sonos won't be able to lookup the metadata for the track.
`parent` should be in the form of the album a track is part of

I suppose this method could be easily extended to support Spotify albums, and whole playlists.
