### PR TITLE
Fixed crash where discovery returns a dict instead of array

### DIFF
--- a/SonosKit/SonosDiscovery.m
+++ b/SonosKit/SonosDiscovery.m
@@ -47,6 +47,10 @@ typedef void (^kFindControllersBlock)(NSArray *ipAddresses);
 
         NSDictionary *responseDict = [XMLReader dictionaryForXMLData:data error:&error];
         NSArray *inputs = responseDict[@"ZPSupportInfo"][@"ZonePlayers"][@"ZonePlayer"];
+		  
+        if(![inputs isKindOfClass:[NSArray class]]) {
+            inputs = @[inputs];
+        }
 
         for (NSDictionary *input in inputs) {
           NSString *ipLocation = input[@"location"];


### PR DESCRIPTION
This happens when you only have one player on your network.
Recreated with SONOS PLAY:1
